### PR TITLE
fix: comment out email display in workspace members table

### DIFF
--- a/apps/client/src/features/group/components/group-members.tsx
+++ b/apps/client/src/features/group/components/group-members.tsx
@@ -67,9 +67,11 @@ export default function GroupMembersList() {
                       <Text fz="sm" fw={500} lineClamp={1}>
                         {user.name}
                       </Text>
+                      {isAdmin && (
                       <Text fz="xs" c="dimmed">
                         {user.email}
                       </Text>
+                      )}
                     </div>
                   </Group>
                 </Table.Td>

--- a/apps/client/src/features/workspace/components/members/components/workspace-members-table.tsx
+++ b/apps/client/src/features/workspace/components/members/components/workspace-members-table.tsx
@@ -36,7 +36,7 @@ export default function WorkspaceMembersTable() {
   const handleRoleChange = async (
     userId: string,
     currentRole: string,
-    newRole: string,
+    newRole: string
   ) => {
     if (newRole === currentRole) {
       return;
@@ -77,9 +77,11 @@ export default function WorkspaceMembersTable() {
                         <Text fz="sm" fw={500} lineClamp={1}>
                           {user.name}
                         </Text>
-                        <Text fz="xs" c="dimmed">
-                          {user.email}
-                        </Text>
+                        {isAdmin && (
+                          <Text fz="xs" c="dimmed">
+                            {user.email}
+                          </Text>
+                        )}
                       </div>
                     </Group>
                   </Table.Td>


### PR DESCRIPTION
管理者権限を持っていないユーザにはEmailアドレスを表示しない。
ただしサーバとのやりとりには含まれるので、完全ではない。